### PR TITLE
Fix prompts volume mapping in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,7 @@ services:
       - ./config.json:/app/config.json:ro
       - ./config.db:/app/config.db
       - ./beta_codes.txt:/app/beta_codes.txt:ro
-      - ../prompts/decision_logs:/app/decision_logs
-      - ../prompts:/app/prompts
+      - ./prompts:/app/prompts
       - ./secrets:/app/secrets:ro  # RSA密钥文件
       - /etc/localtime:/etc/localtime:ro  # Sync host time
     environment:


### PR DESCRIPTION
## Summary
- remove host volume mount for decision_logs to avoid invalid mapping
- use project-local prompts directory as the container prompts volume

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a9fb8c79c83289214d8b0891847a4)